### PR TITLE
Add dashboard, signup, budgets and PWA support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+js/config.js

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # registro-spese-personali
 Sito per la gestione personale delle spese
+
+## Configurazione Firebase
+
+1. Copia `js/config.example.js` in `js/config.js`.
+2. Inserisci le credenziali del tuo progetto Firebase nelle variabili esportate.
+3. `js/config.js` è escluso dal controllo di versione (`.gitignore`).
+
+## Build/Run
+Trattandosi di una semplice app statica, basta servire la cartella del progetto con un web server.

--- a/index.html
+++ b/index.html
@@ -4,59 +4,42 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Riepilogo</title>
-
-  <!-- Bootstrap CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-
-  <!-- Mio CSS -->
   <link rel="stylesheet" href="css/style.css">
+  <link rel="manifest" href="manifest.webmanifest">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 </head>
-
 <body>
-    <!-- Sezione Navbar -->
-  <nav class="navbar py-2 bg-dark border-bottom border-body" data-bs-theme="dark">
-    <div class="container d-flex flex-wrap">
-        <a class="navbar-brand" href="index.html">
-            <img src="IMG/icon.png" alt="Registro spese personali" width="40" height="40">
-        </a>
-        <ul class="nav">
-            <li class="nav-item">   
-                <a type="button" class="btn btn-dark" href="storico.html">                     
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#ffffff" class="bi bi-database" viewBox="0 0 16 16">
-                        <path d="M4.318 2.687C5.234 2.271 6.536 2 8 2s2.766.27 3.682.687C12.644 3.125 13 3.627 13 4c0 .374-.356.875-1.318 1.313C10.766 5.729 9.464 6 8 6s-2.766-.27-3.682-.687C3.356 4.875 3 4.373 3 4c0-.374.356-.875 1.318-1.313M13 5.698V7c0 .374-.356.875-1.318 1.313C10.766 8.729 9.464 9 8 9s-2.766-.27-3.682-.687C3.356 7.875 3 7.373 3 7V5.698c.271.202.58.378.904.525C4.978 6.711 6.427 7 8 7s3.022-.289 4.096-.777A5 5 0 0 0 13 5.698M14 4c0-1.007-.875-1.755-1.904-2.223C11.022 1.289 9.573 1 8 1s-3.022.289-4.096.777C2.875 2.245 2 2.993 2 4v9c0 1.007.875 1.755 1.904 2.223C4.978 15.71 6.427 16 8 16s3.022-.289 4.096-.777C13.125 14.755 14 14.007 14 13zm-1 4.698V10c0 .374-.356.875-1.318 1.313C10.766 11.729 9.464 12 8 12s-2.766-.27-3.682-.687C3.356 10.875 3 10.373 3 10V8.698c.271.202.58.378.904.525C4.978 9.71 6.427 10 8 10s3.022-.289 4.096-.777A5 5 0 0 0 13 8.698m0 3V13c0 .374-.356.875-1.318 1.313C10.766 14.729 9.464 15 8 15s-2.766-.27-3.682-.687C3.356 13.875 3 13.373 3 13v-1.302c.271.202.58.378.904.525C4.978 12.71 6.427 13 8 13s3.022-.289 4.096-.777c.324-.147.633-.323.904-.525"/>
-                    </svg>
-                </a>
-        </button>
-            </li>
-            <li class="nav-item">
-                <a type="button" class="btn btn-dark" href="inserisci.html">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#ffffff" class="bi bi-plus-square" viewBox="0 0 16 16">
-                        <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"></path>
-                        <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4"></path>
-                    </svg>
-                </a>
-            </li>
-        </ul>
-    </div>
-  </nav>
+  <div id="navbar"></div>
 
-  <script type="module">
-    import { requireAuth, currentUser, logout } from "./js/auth.js";
-    requireAuth();
+  <main class="container mt-4">
+    <h1 class="h3 mb-3">Dashboard</h1>
+    <canvas id="chartTotali" height="200"></canvas>
 
-    // navbar attiva + logout
-    const file = (location.pathname.split("/").pop() || "index.html").toLowerCase();
-    document.querySelectorAll('nav a[data-page]').forEach(a=>{
-      if (a.getAttribute('data-page') === file) a.classList.add('fw-bold','text-decoration-underline');
-    });
-    document.getElementById("logoutLink")?.addEventListener("click",(e)=>{ e.preventDefault(); logout(); });
+    <section class="mt-4">
+      <h2 class="h5">Ultime spese</h2>
+      <ul id="ultimeSpese" class="list-group"></ul>
+    </section>
 
-    // mostra email
-    const t = setInterval(()=>{
-      const u = currentUser();
-      if (u) { document.getElementById("who").textContent = `Connesso come ${u.email}`; clearInterval(t); }
-    },200);
-  </script>
+    <section class="mt-4">
+      <h2 class="h5">Budget mensile</h2>
+      <div id="budgetStatus" class="mb-2"></div>
+      <form id="budgetForm" class="row g-2">
+        <div class="col-sm-5">
+          <input id="budgetCategoria" class="form-control" placeholder="Categoria">
+        </div>
+        <div class="col-sm-5">
+          <input id="budgetImporto" type="number" step="0.01" min="0" class="form-control" placeholder="Importo (€)">
+        </div>
+        <div class="col-sm-2">
+          <button class="btn btn-primary w-100" type="submit">Imposta</button>
+        </div>
+      </form>
+    </section>
+  </main>
 
+  <script type="module" src="js/navbar.js"></script>
+  <script type="module" src="js/dashboard.js"></script>
+  <script src="js/sw.js"></script>
 </body>
 </html>

--- a/inserisci.html
+++ b/inserisci.html
@@ -8,30 +8,13 @@
 <link rel="preconnect" href="https://www.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://identitytoolkit.googleapis.com" crossorigin>
 <link rel="preconnect" href="https://firestore.googleapis.com" crossorigin>
+  <link rel="manifest" href="manifest.webmanifest">
 <link rel="stylesheet" href="css/style.css">
 <meta name="robots" content="noindex">
 </head>
 <body>
+  <div id="navbar"></div>
   <!-- Navbar -->
-  <nav class="navbar py-2 bg-dark border-bottom border-body" data-bs-theme="dark">
-    <div class="container d-flex flex-wrap">
-      <a class="navbar-brand" href="index.html">
-        <img src="IMG/icon.png" alt="Registro spese personali" width="40" height="40">
-      </a>
-      <ul class="nav">
-        <li class="nav-item">
-          <a class="btn btn-dark" href="storico.html">
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#ffffff" class="bi bi-database" viewBox="0 0 16 16"><path d="M4.318 2.687C5.234 2.271 6.536 2 8 2s2.766.27 3.682.687C12.644 3.125 13 3.627 13 4c0 .374-.356.875-1.318 1.313C10.766 5.729 9.464 6 8 6s-2.766-.27-3.682-.687C3.356 4.875 3 4.373 3 4c0-.374.356-.875 1.318-1.313M13 5.698V7c0 .374-.356.875-1.318 1.313C10.766 8.729 9.464 9 8 9s-2.766-.27-3.682-.687C3.356 7.875 3 7.373 3 7V5.698c.271.202.58.378.904.525C4.978 6.711 6.427 7 8 7s3.022-.289 4.096-.777A5 5 0 0 0 13 5.698M14 4c0-1.007-.875-1.755-1.904-2.223C11.022 1.289 9.573 1 8 1s-3.022.289-4.096.777C2.875 2.245 2 2.993 2 4v9c0 1.007.875 1.755 1.904 2.223C4.978 15.71 6.427 16 8 16s3.022-.289 4.096-.777C13.125 14.755 14 14.007 14 13zm-1 4.698V10c0 .374-.356.875-1.318 1.313C10.766 11.729 9.464 12 8 12s-2.766-.27-3.682-.687C3.356 10.875 3 10.373 3 10V8.698c.271.202.58.378.904.525C4.978 9.71 6.427 10 8 10s3.022-.289 4.096-.777c.324-.147.633-.323.904-.525"/></svg>
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="btn btn-dark" href="inserisci.html">
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#ffffff" class="bi bi-plus-square" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"></path><path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4"></path></svg>
-          </a>
-        </li>
-      </ul>
-    </div>
-  </nav>
 
   <div class="container mt-2" style="max-width:700px">
     <div id="msg"></div>
@@ -157,8 +140,9 @@
     </form>
   </div>
 
+<script type="module" src="js/navbar.js"></script>
   <script type="module">
-    import { requireAuth, logout } from "./js/auth.js";
+    import { requireAuth } from "./js/auth.js";
     import { addSpesa, addSerieRicorrente, materializeSerie } from "./js/spese.js";
     requireAuth();
 
@@ -271,5 +255,6 @@
       }
     });
   </script>
+  <script src="js/sw.js"></script>
 </body>
 </html>

--- a/js/auth.js
+++ b/js/auth.js
@@ -2,7 +2,7 @@
 import { auth } from "./db.js";
 import {
   onAuthStateChanged,
-  signInWithEmailAndPassword,
+  signInWithEmailAndPassword, createUserWithEmailAndPassword,
   signOut,
 } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js";
 
@@ -18,7 +18,7 @@ const redirect = (url) => location.replace(url);
 // Se sei già loggato, non ha senso stare su login
 export function bounceIfLogged() {
   onAuthStateChanged(auth, (user) => {
-    if (user && currentFile() === "login.html") {
+    if (user && (currentFile() === "login.html" || currentFile() === "signup.html")) {
       const back = new URL(location.href).searchParams.get("from");
       redirect(back || "index.html");
     }
@@ -44,7 +44,9 @@ export function emailLogin(email, password) {
   return signInWithEmailAndPassword(auth, email, password);
 }
 
-// Logout
+export function emailSignup(email, password) {
+  return createUserWithEmailAndPassword(auth, email, password);
+}
 export async function logout() {
   await signOut(auth);
   redirect("login.html");

--- a/js/config.example.js
+++ b/js/config.example.js
@@ -1,0 +1,8 @@
+export const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_STORAGE_BUCKET",
+  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+  appId: "YOUR_APP_ID"
+};

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,0 +1,58 @@
+import { requireAuth } from './auth.js';
+import { getUltimeSpese, filtraPerMese, euro, setBudget, getBudget } from './spese.js';
+
+requireAuth();
+
+(async function(){
+  try{
+    const spese = await getUltimeSpese(200);
+    const now = new Date();
+    const ym = `${now.getFullYear()}-${String(now.getMonth()+1).padStart(2,'0')}`;
+    const mese = filtraPerMese(spese, ym);
+    const totCat = {};
+    mese.forEach(s=>{ totCat[s.categoria] = (totCat[s.categoria] || 0) + Number(s.importo); });
+
+    const ctx = document.getElementById('chartTotali');
+    if(ctx){
+      new Chart(ctx,{type:'pie',data:{labels:Object.keys(totCat),datasets:[{data:Object.values(totCat)}]},options:{plugins:{legend:{position:'bottom'}}}});
+    }
+
+    const ul = document.getElementById('ultimeSpese');
+    if(ul){
+      ul.innerHTML = spese.slice(0,5).map(s=>`<li class="list-group-item d-flex justify-content-between"><span>${s.data} - ${s.descrizione}</span><span>${euro(s.importo)}</span></li>`).join('');
+    }
+
+    let budget = await getBudget(ym);
+    renderBudget(budget, totCat);
+
+    document.getElementById('budgetForm')?.addEventListener('submit', async e=>{
+      e.preventDefault();
+      const cat = document.getElementById('budgetCategoria').value.trim();
+      const imp = document.getElementById('budgetImporto').value;
+      if(cat && imp){
+        await setBudget(cat, imp, ym);
+        document.getElementById('budgetCategoria').value='';
+        document.getElementById('budgetImporto').value='';
+        budget = await getBudget(ym);
+        renderBudget(budget, totCat);
+      }
+    });
+  }catch(err){
+    console.error(err);
+  }
+})();
+
+function renderBudget(budget, totCat){
+  const div = document.getElementById('budgetStatus');
+  if(!div) return;
+  const entries = Object.entries(budget || {});
+  if(!entries.length){
+    div.textContent = 'Nessun budget definito.';
+    return;
+  }
+  div.innerHTML = entries.map(([cat,lim])=>{
+    const spent = totCat[cat] || 0;
+    const cls = spent > lim ? 'text-danger' : '';
+    return `<div class="${cls}">${cat}: ${euro(spent)} / ${euro(lim)}</div>`;
+  }).join('');
+}

--- a/js/db.js
+++ b/js/db.js
@@ -3,15 +3,7 @@ import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.5/fireba
 import { getAuth }        from "https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js";
 import { getFirestore }   from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
 
-// Config (quella già usata nel tuo progetto)
-const firebaseConfig = {
-  apiKey: "AIzaSyB76HrqxMp0EuPsedVMBJaz6MW5qHdFr10",
-  authDomain: "gestione-spese-personale.firebaseapp.com",
-  projectId: "gestione-spese-personale",
-  storageBucket: "gestione-spese-personale.firebasestorage.app",
-  messagingSenderId: "659511690509",
-  appId: "1:659511690509:web:c1eb2a8c1b0b10ce469c44"
-};
+import { firebaseConfig } from "./config.js";
 
 export const app  = initializeApp(firebaseConfig);
 export const auth = getAuth(app);

--- a/js/navbar.js
+++ b/js/navbar.js
@@ -1,0 +1,17 @@
+import { logout } from "./auth.js";
+
+async function loadNavbar(){
+  const container = document.getElementById('navbar');
+  if(!container) return;
+  const res = await fetch('partials/navbar.html');
+  container.innerHTML = await res.text();
+
+  const file = (location.pathname.split('/').pop() || 'index.html').toLowerCase();
+  container.querySelectorAll('a[data-page]').forEach(a=>{
+    if(a.getAttribute('data-page')===file) a.classList.add('fw-bold','text-decoration-underline');
+  });
+  container.querySelector('#logoutLink')?.addEventListener('click',e=>{e.preventDefault();logout();});
+}
+
+loadNavbar();
+

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,0 +1,19 @@
+import { emailSignup, bounceIfLogged } from './auth.js';
+
+bounceIfLogged();
+
+const form = document.getElementById('signupForm');
+const msg  = document.getElementById('msg');
+
+form?.addEventListener('submit', async e => {
+  e.preventDefault();
+  msg.innerHTML = '';
+  const email = document.getElementById('email').value.trim();
+  const pass  = document.getElementById('password').value;
+  try{
+    await emailSignup(email, pass);
+    location.href = 'index.html';
+  }catch(err){
+    msg.innerHTML = `<div class="alert alert-danger" role="alert">${err.message}</div>`;
+  }
+});

--- a/js/spese.js
+++ b/js/spese.js
@@ -1,7 +1,7 @@
 // js/spese.js
 import { auth, db } from "./db.js";
 import {
-  addDoc, setDoc, updateDoc,
+  addDoc, setDoc, updateDoc, deleteDoc,
   collection, doc, getDoc, getDocs,
   orderBy, query, limit
 } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
@@ -43,6 +43,31 @@ export async function addSpesa(payload) {
   const col = collection(db, "users", uid, "spese");
   await addDoc(col, docData);
 }
+export async function updateSpesa(id, payload) {
+  const uid = await currentUid();
+  const ref = doc(db, "users", uid, "spese", id);
+  const snap = await getDoc(ref);
+  if(!snap.exists() || snap.data().userId !== uid) throw new Error("Non autorizzato");
+  const data = {};
+  if(payload.data !== undefined) data.data = payload.data;
+  if(payload.descrizione !== undefined) data.descrizione = payload.descrizione;
+  if(payload.importo !== undefined) data.importo = Number(payload.importo);
+  if(payload.categoria !== undefined) data.categoria = payload.categoria;
+  if(payload.etichette !== undefined) {
+    data.etichette = Array.isArray(payload.etichette) ? payload.etichette : (typeof payload.etichette === "string" ? payload.etichette.split(",").map(s=>s.trim()).filter(Boolean) : []);
+  }
+  data.updatedAt = new Date().toISOString();
+  await updateDoc(ref, data);
+}
+
+export async function deleteSpesa(id){
+  const uid = await currentUid();
+  const ref = doc(db, "users", uid, "spese", id);
+  const snap = await getDoc(ref);
+  if(!snap.exists() || snap.data().userId !== uid) throw new Error("Non autorizzato");
+  await deleteDoc(ref);
+}
+
 
 export async function getUltimeSpese(max = 200) {
   const uid = await currentUid();
@@ -50,6 +75,19 @@ export async function getUltimeSpese(max = 200) {
   const qy  = query(col, orderBy("data", "desc"), limit(max));
   const snap = await getDocs(qy);
   return snap.docs.map(d => ({ id: d.id, ...d.data() }));
+}
+
+export async function setBudget(categoria, importo, mese){
+  const uid = await currentUid();
+  const ref = doc(db, "users", uid, "budgets", mese);
+  await setDoc(ref, { [categoria]: Number(importo) }, { merge: true });
+}
+
+export async function getBudget(mese){
+  const uid = await currentUid();
+  const ref = doc(db, "users", uid, "budgets", mese);
+  const snap = await getDoc(ref);
+  return snap.exists()?snap.data():{};
 }
 
 export function filtraPerMese(spese, yearMonth) {

--- a/js/sw.js
+++ b/js/sw.js
@@ -1,0 +1,3 @@
+if('serviceWorker' in navigator){
+  navigator.serviceWorker.register('service-worker.js').catch(()=>{});
+}

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,12 @@
+{
+  "name": "Registro Spese Personali",
+  "short_name": "Spese",
+  "start_url": "index.html",
+  "display": "standalone",
+  "background_color": "#121212",
+  "theme_color": "#121212",
+  "icons": [
+    { "src": "IMG/icon.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "IMG/icon.png", "sizes": "512x512", "type": "image/png" }
+  ]
+}

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -1,0 +1,27 @@
+<nav class="navbar py-2 bg-dark border-bottom border-body" data-bs-theme="dark">
+  <div class="container d-flex flex-wrap">
+    <a class="navbar-brand" href="index.html">
+      <img src="IMG/icon.png" alt="Registro spese personali" width="40" height="40">
+    </a>
+    <ul class="nav ms-auto">
+      <li class="nav-item">
+        <a data-page="storico.html" class="btn btn-dark" href="storico.html">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#ffffff" class="bi bi-database" viewBox="0 0 16 16">
+            <path d="M4.318 2.687C5.234 2.271 6.536 2 8 2s2.766.27 3.682.687C12.644 3.125 13 3.627 13 4c0 .374-.356.875-1.318 1.313C10.766 5.729 9.464 6 8 6s-2.766-.27-3.682-.687C3.356 4.875 3 4.373 3 4c0-.374.356-.875 1.318-1.313M13 5.698V7c0 .374-.356.875-1.318 1.313C10.766 8.729 9.464 9 8 9s-2.766-.27-3.682-.687C3.356 7.875 3 7.373 3 7V5.698c.271.202.58.378.904.525C4.978 6.711 6.427 7 8 7s3.022-.289 4.096-.777A5 5 0 0 0 13 5.698M14 4c0-1.007-.875-1.755-1.904-2.223C11.022 1.289 9.573 1 8 1s-3.022.289-4.096.777C2.875 2.245 2 2.993 2 4v9c0 1.007.875 1.755 1.904 2.223C4.978 15.71 6.427 16 8 16s3.022-.289 4.096-.777C13.125 14.755 14 14.007 14 13zm-1 4.698V10c0 .374-.356.875-1.318 1.313C10.766 11.729 9.464 12 8 12s-2.766-.27-3.682-.687C3.356 10.875 3 10.373 3 10V8.698c.271.202.58.378.904.525C4.978 9.71 6.427 10 8 10s3.022-.289 4.096-.777c.324-.147.633-.323.904-.525"/>
+          </svg>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a data-page="inserisci.html" class="btn btn-dark" href="inserisci.html">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#ffffff" class="bi bi-plus-square" viewBox="0 0 16 16">
+            <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/>
+            <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4"/>
+          </svg>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a id="logoutLink" class="btn btn-dark" href="#">Logout</a>
+      </li>
+    </ul>
+  </div>
+</nav>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,29 @@
+const CACHE_NAME = 'spese-cache-v1';
+const ASSETS = [
+  '/',
+  'index.html',
+  'inserisci.html',
+  'storico.html',
+  'login.html',
+  'signup.html',
+  'css/style.css',
+  'js/auth.js',
+  'js/spese.js',
+  'js/login.js',
+  'js/signup.js',
+  'js/dashboard.js',
+  'js/navbar.js',
+  'js/sw.js',
+  'partials/navbar.html',
+  'manifest.webmanifest'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS)));
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});

--- a/signup.html
+++ b/signup.html
@@ -3,47 +3,40 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Accedi</title>
-
-  <!-- Bootstrap CSS -->
+  <title>Registrati</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-
-    <link rel="manifest" href="manifest.webmanifest">
-  <!-- Mio CSS -->
   <link rel="stylesheet" href="css/style.css">
-
+  <link rel="manifest" href="manifest.webmanifest">
 </head>
 <body class="container min-vh-100 d-flex flex-column justify-content-center align-items-center gap-4">
   <main class="container">
     <div class="container text-center">
-      <img class="mb-4" src="IMG/icon.png" alt="" width="72" height="57">
+      <img class="mb-4" src="IMG/icon.png" width="72" height="57" alt="">
     </div>
     <div class="container">
       <div class="card mx-auto p-2 shadow-sm" style="max-width: 420px">
-        <div class="card-header text-center">
-        Accedi
-        </div>
+        <div class="card-header text-center">Registrati</div>
         <div class="card-body">
-          <form id="loginForm" class="login-form mx-auto" novalidate>
+          <form id="signupForm" class="mx-auto" novalidate>
             <div class="mb-3">
               <label class="form-label" for="email">E-mail</label>
               <input id="email" type="email" class="form-control" required autocomplete="username">
             </div>
             <div class="mb-3">
               <label class="form-label" for="password">Password</label>
-              <input id="password" type="password" class="form-control" required autocomplete="current-password">
+              <input id="password" type="password" class="form-control" required autocomplete="new-password">
             </div>
-            <button class="btn btn-primary w-100" type="submit">Entra</button>
+            <button class="btn btn-primary w-100" type="submit">Crea account</button>
           </form>
-            <div class="mt-3 text-center"><a href="signup.html">Registrati</a></div>
+          <div class="mt-3 text-center">
+            <a href="login.html">Hai già un account? Accedi</a>
+          </div>
         </div>
       </div>
     </div>
     <div id="msg" class="mb-3" role="status" aria-live="polite"></div>
   </main>
-
-  <!-- JS di pagina -->
-  <script type="module" src="js/login.js"></script>
-<script src="js/sw.js"></script>
+  <script type="module" src="js/signup.js"></script>
+  <script src="js/sw.js"></script>
 </body>
 </html>

--- a/storico.html
+++ b/storico.html
@@ -8,36 +8,13 @@
 <link rel="preconnect" href="https://www.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://identitytoolkit.googleapis.com" crossorigin>
 <link rel="preconnect" href="https://firestore.googleapis.com" crossorigin>
+  <link rel="manifest" href="manifest.webmanifest">
 <link rel="stylesheet" href="css/style.css">
 <meta name="robots" content="noindex">
 </head>
 <body>
+  <div id="navbar"></div>
   <!-- Sezione Navbar -->
-  <nav class="navbar py-2 bg-dark border-bottom border-body" data-bs-theme="dark">
-    <div class="container d-flex flex-wrap">
-        <a class="navbar-brand" href="index.html">
-            <img src="IMG/icon.png" alt="Registro spese personali" width="40" height="40">
-        </a>
-        <ul class="nav">
-            <li class="nav-item">   
-                <a type="button" class="btn btn-dark" href="storico.html">                     
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#ffffff" class="bi bi-database" viewBox="0 0 16 16">
-                        <path d="M4.318 2.687C5.234 2.271 6.536 2 8 2s2.766.27 3.682.687C12.644 3.125 13 3.627 13 4c0 .374-.356.875-1.318 1.313C10.766 5.729 9.464 6 8 6s-2.766-.27-3.682-.687C3.356 4.875 3 4.373 3 4c0-.374.356-.875 1.318-1.313M13 5.698V7c0 .374-.356.875-1.318 1.313C10.766 8.729 9.464 9 8 9s-2.766-.27-3.682-.687C3.356 7.875 3 7.373 3 7V5.698c.271.202.58.378.904.525C4.978 6.711 6.427 7 8 7s3.022-.289 4.096-.777A5 5 0 0 0 13 5.698M14 4c0-1.007-.875-1.755-1.904-2.223C11.022 1.289 9.573 1 8 1s-3.022.289-4.096.777C2.875 2.245 2 2.993 2 4v9c0 1.007.875 1.755 1.904 2.223C4.978 15.71 6.427 16 8 16s3.022-.289 4.096-.777C13.125 14.755 14 14.007 14 13zm-1 4.698V10c0 .374-.356.875-1.318 1.313C10.766 11.729 9.464 12 8 12s-2.766-.27-3.682-.687C3.356 10.875 3 10.373 3 10V8.698c.271.202.58.378.904.525C4.978 9.71 6.427 10 8 10s3.022-.289 4.096-.777A5 5 0 0 0 13 8.698m0 3V13c0 .374-.356.875-1.318 1.313C10.766 14.729 9.464 15 8 15s-2.766-.27-3.682-.687C3.356 13.875 3 13.373 3 13v-1.302c.271.202.58.378.904.525C4.978 12.71 6.427 13 8 13s3.022-.289 4.096-.777c.324-.147.633-.323.904-.525"/>
-                    </svg>
-                </a>
-        </button>
-            </li>
-            <li class="nav-item">
-                <a type="button" class="btn btn-dark" href="inserisci.html">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#ffffff" class="bi bi-plus-square" viewBox="0 0 16 16">
-                        <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"></path>
-                        <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4"></path>
-                    </svg>
-                </a>
-            </li>
-        </ul>
-    </div>
-  </nav>
   
   <h1 class="text-center mt-4">📚 Storico</h1>
 
@@ -69,26 +46,22 @@
             <th>Categoria</th>
             <th class="text-end">Importo</th>
             <th>Etichette</th>
+            <th>Azioni</th>
           </tr>
         </thead>
         <tbody id="tbody">
-          <tr><td colspan="5" class="text-center text-muted">Caricamento…</td></tr>
+          <tr><td colspan="6" class="text-center text-muted">Caricamento…</td></tr>
         </tbody>
       </table>
     </div>
   </div>
 
+<script type="module" src="js/navbar.js"></script>
   <script type="module">
-    import { requireAuth, logout } from "./js/auth.js";
-    import { getUltimeSpese, filtraPerMese, euro } from "./js/spese.js";
+    import { requireAuth } from "./js/auth.js";
+    import { getUltimeSpese, filtraPerMese, euro, updateSpesa, deleteSpesa } from "./js/spese.js";
     requireAuth();
 
-    // navbar attiva + logout
-    const file = (location.pathname.split("/").pop() || "index.html").toLowerCase();
-    document.querySelectorAll('nav a[data-page]').forEach(a=>{
-      if (a.getAttribute('data-page') === file) a.classList.add('fw-bold','text-decoration-underline');
-    });
-    document.getElementById("logoutLink")?.addEventListener("click",(e)=>{ e.preventDefault(); logout(); });
 
     const tbody  = document.getElementById("tbody");
     const inputM = document.getElementById("mese");
@@ -103,13 +76,14 @@
     await carica();
 
     document.getElementById("btnFiltra").addEventListener("click", render);
+  tbody.addEventListener("click", onAction);
 
     async function carica() {
       try {
         cache = await getUltimeSpese(300);
         render();
       } catch (e) {
-        tbody.innerHTML = `<tr><td colspan="5" class="text-danger text-center">${e.message}</td></tr>`;
+        tbody.innerHTML = `<tr><td colspan="6" class="text-danger text-center">${e.message}</td></tr>`;
       }
     }
 
@@ -122,8 +96,8 @@
         data = data.filter(s =>
           (s.descrizione || "").toLowerCase().includes(q) ||
           (Array.isArray(s.etichette) ? s.etichette.join(",") : "").toLowerCase().includes(q)
-        );
-      }
+          );
+        }
 
       // totale
       const tot = data.reduce((sum, s) => sum + Number(s.importo || 0), 0);
@@ -131,7 +105,7 @@
 
       // tabella
       if (!data.length) {
-        tbody.innerHTML = `<tr><td colspan="5" class="text-center text-muted">Nessuna spesa per il mese selezionato.</td></tr>`;
+        tbody.innerHTML = `<tr><td colspan="6" class="text-center text-muted">Nessuna spesa per il mese selezionato.</td></tr>`;
         return;
       }
 
@@ -142,8 +116,33 @@
           <td>${escapeHtml(s.categoria || "")}</td>
           <td class="text-end">${euro(s.importo)}</td>
           <td>${Array.isArray(s.etichette) ? s.etichette.map(t => `<span class="badge text-bg-light me-1">${escapeHtml(t)}</span>`).join("") : ""}</td>
+          <td class="text-end"><button class="btn btn-sm btn-outline-secondary me-1 edit" data-id="${s.id}">Modifica</button><button class="btn btn-sm btn-outline-danger delete" data-id="${s.id}">Elimina</button></td>
         </tr>
       `).join("");
+    }
+
+    async function onAction(e){
+      const id = e.target.dataset.id;
+      if(!id) return;
+      if(e.target.classList.contains("delete")){
+        if(confirm("Eliminare questa spesa?")){
+          await deleteSpesa(id);
+          cache = cache.filter(s=>s.id!==id);
+          render();
+        }
+      } else if(e.target.classList.contains("edit")){
+        const sp = cache.find(s=>s.id===id);
+        const d = prompt("Descrizione", sp.descrizione);
+        if(d!==null){
+          const imp = prompt("Importo", sp.importo);
+          if(imp!==null){
+            await updateSpesa(id,{descrizione:d, importo:Number(imp)});
+            sp.descrizione=d;
+            sp.importo=Number(imp);
+            render();
+          }
+        }
+      }
     }
 
     function escapeHtml(str) {
@@ -152,5 +151,6 @@
       );
     }
   </script>
+  <script src="js/sw.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add dashboard with latest expenses, category chart and monthly budgets
- centralize navbar and enable basic edit/delete actions on expense history
- support user registration and externalize Firebase config
- enable offline use with service worker and web manifest

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acaded8970832281ca42520a4d2d10