### PR TITLE
Skip cross-origin requests in service worker

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -23,6 +23,10 @@ self.addEventListener('install', event => {
 });
 
 self.addEventListener('fetch', event => {
+  const requestOrigin = new URL(event.request.url).origin;
+  if (requestOrigin !== self.location.origin) {
+    return;
+  }
   event.respondWith(
     caches.match(event.request).then(resp => resp || fetch(event.request))
   );


### PR DESCRIPTION
## Summary
- Prevent the service worker from intercepting requests to other origins

## Testing
- `npm test` *(fails: ENOENT, package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acb6b8bae48322ab4f6696d329a06d